### PR TITLE
Migrate to postcss v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 cache: yarn
 node_js:
   - stable
-  - "6"
-  - "4"
+  - "14"
+  - "12"
+  - "10"

--- a/index.js
+++ b/index.js
@@ -1,46 +1,49 @@
-var postcss = require('postcss');
-var extend = require('util')._extend;
+'use strict'
 
-var defaultOptions = {
+const defaultOptions = {
     addAttribute: true,
     addClass: false
-};
+}
 
-module.exports = postcss.plugin('postcss-disabled', function (opts) {
+module.exports = opts => {
+    opts = {
+        ...defaultOptions,
+        ...opts
+    }
 
-    opts = extend(extend({}, defaultOptions), opts);
+    return {
+        postcssPlugin: 'postcss-disabled',
 
-    return function (root) {
+        Once (root) {
+            root.walkRules(rule => {
+                if (rule.selector.includes(':disabled')) {
+                    let disabledSelectors = []
 
-        root.walkRules(function (rule) {
+                    for (let selector of rule.selectors) {
+                        if (selector.includes(':disabled')) {
+                            if (opts.addClass) {
+                                disabledSelectors.push(
+                                    selector.replace(/:disabled/g, '.disabled')
+                                )
+                            }
 
-            if (rule.selector.indexOf(':disabled') !== -1) {
-
-                var disabledSelectors = [];
-
-                rule.selectors.forEach(function (selector) {
-
-                    if (selector.indexOf(':disabled') !== -1) {
-
-                        if (opts.addClass) {
-                            disabledSelectors.push(
-                                selector.replace(/:disabled/g, '.disabled')
-                            );
-                        }
-
-                        if (opts.addAttribute) {
-                            disabledSelectors.push(
-                                selector.replace(/:disabled/g, '[disabled]')
-                            );
+                            if (opts.addAttribute) {
+                                disabledSelectors.push(
+                                    selector.replace(/:disabled/g, '[disabled]')
+                                )
+                            }
                         }
                     }
-                });
 
-                if (disabledSelectors.length) {
-                    rule.selectors = rule.selectors.concat(disabledSelectors);
+                    if (disabledSelectors.length) {
+                        rule.selectors = rule.selectors.concat(
+                            disabledSelectors
+                        )
+                    }
                 }
-            }
-        });
+            })
+        }
+    }
+}
 
-    };
-});
+module.exports.postcss = true

--- a/index.test.js
+++ b/index.test.js
@@ -1,55 +1,53 @@
-var postcss = require('postcss');
+'use strict'
 
-var plugin = require('./');
+const postcss = require('postcss')
+const plugin = require('./')
 
-var test = function (input, output, opts) {
-    return postcss([ plugin(opts) ]).process(input)
-        .then(function (result) {
-            expect(result.css).toEqual(output);
-            expect(result.warnings().length).toBe(0);
-        });
-};
+const check = async (input, output, options) => {
+    const from = 'example.css'
+    const result = await postcss([plugin(options)]).process(input, { from })
 
-describe('postcss-disabled', function () {
+    expect(result.css).toEqual(output)
+    expect(result.warnings()).toHaveLength(0)
+}
 
-    it('default behavior, no options', function () {
-        return test(
+describe('postcss-disabled', () => {
+    it('default behavior, no options', () => {
+        return check(
             '.foo:disabled { background-color: #f9f9f9; }',
-            '.foo:disabled, .foo[disabled] { background-color: #f9f9f9; }',
-            {}
-        );
-    });
+            '.foo:disabled, .foo[disabled] { background-color: #f9f9f9; }'
+        )
+    })
 
-    it('addAttributes: true', function () {
-        return test(
+    it('addAttributes: true', () => {
+        return check(
             '.foo:disabled { background-color: #f9f9f9; }',
             '.foo:disabled, .foo[disabled] { background-color: #f9f9f9; }',
             { addAttribute: true }
-        );
-    });
+        )
+    })
 
-    it('addAttributes: false', function () {
-        return test(
+    it('addAttributes: false', () => {
+        return check(
             '.foo:disabled { background-color: #f9f9f9; }',
             '.foo:disabled { background-color: #f9f9f9; }',
             { addAttribute: false }
-        );
-    });
+        )
+    })
 
-    it('addClass: true', function () {
-        return test(
+    it('addClass: true', () => {
+        return check(
             '.foo:disabled { background-color: #f9f9f9; }',
             '.foo:disabled, .foo.disabled, .foo[disabled] { background-color: #f9f9f9; }',
             { addClass: true }
-        );
-    });
+        )
+    })
 
-    it('addClass: false', function () {
-        return test(
+    it('addClass: false', () => {
+        return check(
             '.foo:disabled { background-color: #f9f9f9; }',
             '.foo:disabled, .foo[disabled] { background-color: #f9f9f9; }',
             { addClass: false }
-        );
-    });
-
-});
+        )
+    })
+})

--- a/package.json
+++ b/package.json
@@ -15,21 +15,40 @@
     "url": "https://github.com/cocco3/postcss-disabled/issues"
   },
   "homepage": "https://github.com/cocco3/postcss-disabled",
-  "dependencies": {
-    "postcss": "^5.2.6"
-  },
   "devDependencies": {
-    "eslint": "^3.12.2",
-    "eslint-config-postcss": "^2.0.2",
-    "jest": "^18.0.0"
+    "@logux/eslint-config": "^41.0.1",
+    "eslint": "^7.11.0",
+    "eslint-config-postcss": "^4.0.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prefer-let": "^1.1.0",
+    "eslint-plugin-prettierx": "^0.14.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-security": "^1.4.0",
+    "eslint-plugin-standard": "^4.0.1",
+    "eslint-plugin-unicorn": "^23.0.0",
+    "jest": "^26.6.0",
+    "postcss": "^8.1.2"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   },
   "scripts": {
     "test": "jest && eslint *.js"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "eslintConfig": {
-    "extends": "eslint-config-postcss/es5",
+    "extends": "eslint-config-postcss",
     "rules": {
-      "max-len": "off"
+      "max-len": "off",
+      "jest/consistent-test-it": "off",
+      "jest/no-identical-title": "off",
+      "import/order": "off",
+      "prefer-let/prefer-let": "off"
     },
     "env": {
       "jest": true


### PR DESCRIPTION
Migrated to [postcss v8](https://evilmartians.com/chronicles/postcss-8-plugin-migration) with help of [@putout/plugin-postcss](https://github.com/coderaiser/putout/tree/master/packages/plugin-postcss). Also updated [eslint-config-postcss](https://github.com/postcss/eslint-config-postcss) to v4.